### PR TITLE
Add Doc Prop Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.3.0-beta] - 2020-07-15
-
 ### Added
 - Doc Prop trigger
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.0-beta] - 2020-07-15
+
+### Added
+- Doc Prop trigger
+
+### Removed 
+- Handmade props table
+
 ## [0.2.0] - 2020-03-30
 ### Added
 - Pass query string to iframe URL.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,11 +43,7 @@ An app that makes it possible to render external iframes on a store
  ...
  ```
 
-| Prop name | Type | Description | Default value |
-|--------------|--------|--------------| --------|
-| `src` | String | Source address the iframe should render | `null`
-| `width` | Number | Width attribute of the iframe | `null`
-| `height` | Number | Height attribute of the iframe | `null`
+%PROPS=Iframe%
 
 ## Configuration - dynamic Iframe
 
@@ -86,12 +82,7 @@ An app that makes it possible to render external iframes on a store
   },
 ```
 
-| Prop name | Type | Description | Default value |
-|--------------|--------|--------------| --------|
-| `dynamicSrc` | String | iframe src with dynamic parameters from page URL enclosed in '{}' | `null`
-| `width` | Number | Width attribute of the iframe | `null`
-| `height` | Number | Height attribute of the iframe | `null`
-| `title` | String | title attribute of the iframe tag | `null`
+%PROPS=DynamicIframe%
 
 ## Customization
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "iframe",
-  "version": "0.2.0",
+  "version": "0.3.0-beta",
   "title": "Iframe",
   "description": "An app to use sourced iframes",
   "defaultLocale": "pt-BR",


### PR DESCRIPTION
#### What problem is this solving?

Added integration with [Doc Prop](https://github.com/vtex-apps/doc-prop) via markdown placeholder.

#### How to test it?

**>> fixing**

#### Screenshots or example usage:

Same behaviour as https://juzon--appliancetheme.myvtex.com/docs/props/app/vtex.doc-prop-component@0.0.4/Countdown

#### Related to / Depends on

To be fully functional on the IO Docs, depends on the [PR](https://github.com/vtex-apps/docs-ui/pull/96) on Docs-UI.
