### PR TITLE
Changed example for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Param names in README.md example to match across code snippets
 
 ## [0.3.0] - 2021-03-10
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ An app that makes it possible to render external iframes on a store.
   },
   "iframe.dynamic-src":{
     "props": {
-      "dynamicSrc": "https://www.test.com/exampleStaticPathName/{dynamicParam1}/{dynamicParam2}/exampleStaticPageName",
+      "dynamicSrc": "https://www.test.com/exampleStaticPathName/{param1}/{param2}/exampleStaticPageName",
       "width": "1920",
       "height": "1000",
       "title": "exampleStaticPageName iframe wrapper for {account}",


### PR DESCRIPTION
Changed parameter names so they matched across code snippets

#### What problem is this solving?

An inconsistency in parameter naming in different code snippets led a user to a bit of confusion. So I edited them to match.

#### How to test it?

No need to test

#### Screenshots or example usage:

No need for screen

#### Describe alternatives you've considered, if any.

Changing parameter names the other way around, so they would be `dynamicParam1` and `dynamicParam2` in both places.

#### Related to / Depends on

Feedback received in this thread:

https://vtex.slack.com/archives/C6A20RM55/p1617974816053800

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/tGZRCBAPhCXxm/giphy.gif)
