### PR TITLE
feat: add block class to iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- BlockClass to iFrame
 
 ## [0.4.0] - 2021-07-13
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,13 @@ An app that makes it possible to render external iframes on a store.
 
 ## Customization
 
-There is a `.container` handle that wraps the iframe, it's also possible to use `blockClass`.
+
+In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
+
+| CSS Handles                | 
+| -------------------------- |
+| `container`                |
+| `iframe`                   |
 
 <!-- DOCS-IGNORE:start -->
 ## Contributors ✨

--- a/react/Iframe.tsx
+++ b/react/Iframe.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 
-const CSS_HANDLES = ['container','iframe'] as const
+const CSS_HANDLES = ['container', 'iframe'] as const
 
 interface Props {
   src?: string

--- a/react/Iframe.tsx
+++ b/react/Iframe.tsx
@@ -23,7 +23,7 @@ function Iframe({ src, width, height, title, allow }: Props) {
         height={height}
         allow={allow}
         frameBorder="0"
-        className={`${handles.iframe}`}
+        className={`${handles.iframe}` }
       />
     </div>
   )

--- a/react/Iframe.tsx
+++ b/react/Iframe.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 
-const CSS_HANDLES = ['container'] as const
+const CSS_HANDLES = ['container','iframe'] as const
 
 interface Props {
   src?: string
@@ -23,6 +23,7 @@ function Iframe({ src, width, height, title, allow }: Props) {
         height={height}
         allow={allow}
         frameBorder="0"
+        className={`${handles.iframe}`}
       />
     </div>
   )


### PR DESCRIPTION
#### What problem is this solving?

The iframe itself needs a `flex:1 1 auto` to stretch into flexbox, but he haven't css handler.

``` jsx
    <div className={`${handles.container} w-100 flex justify-center`}>
      <iframe
        title={title}
        src={src}
        width={width}
        height={height}
        allow={allow}
        frameBorder="0"
      />
    </div>
```
#### Proposed solution

only can customize this element via CSS handlers

``` diff
  <div className={`${handles.container} w-100 flex justify-center`}>
      <iframe
        title={title}
        src={src}
        width={width}
        height={height}
        allow={allow}
        frameBorder="0"
+        className={`${handles.iframe}`}
      />
  </div>
```

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/33559104/130421747-ab13205a-a920-45ce-ac9c-0ffc4a7159c0.png)

