### PR TITLE
Added feature to have custom src per account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New prop `srcAccount`
+
 ## [0.6.0] - 2023-05-15
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,26 @@ An app that makes it possible to render external iframes on a store.
 | `id`         | String | ID attribute of the iframe                                        | `null`        |
 | `className`  | String | class attribute of the iframe                                     | `null`        |
 | `onLoad`     | String | onLoad attribute of the iframe                                    | `null`        |
+| `srcAccount` | Object | Object with account name and src                                  | `null`        |
+
+### srcAccount
+
+Using srcAccount
+
+```json
+  "iframe#logout": {
+    "props": {
+      "src": "//www.mywebsiteprod.com/logout",
+      "srcAccount": {
+        "mywebsiteprod": "//www.mywebsite.com/logout",
+        "mywebsiteqa": "//qa.mywebsite.com/logout"
+      },
+      "onLoad": "setTimeout(() => {window.location.href='/'}, 5000)",
+      "className": "iframeLogout",
+      "id": "iframeLogout"
+    }
+  },
+```
 
 ## Customization
 

--- a/react/Iframe.tsx
+++ b/react/Iframe.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable no-console */
 import React from 'react'
 import { useCssHandles } from 'vtex.css-handles'
+import { useRuntime } from 'vtex.render-runtime'
 
 const CSS_HANDLES = ['container'] as const
 
 interface Props {
   src?: string
+  srcAccount?: any
   width?: number
   height?: number
   allow?: string
@@ -16,8 +18,19 @@ interface Props {
 }
 
 function Iframe(props: Props) {
-  const { src, width, height, title, allow, id, className, onLoad } = props
+  const {
+    src,
+    srcAccount,
+    width,
+    height,
+    title,
+    allow,
+    id,
+    className,
+    onLoad,
+  } = props
   const handles = useCssHandles(CSS_HANDLES)
+  const runtime = useRuntime()
 
   const handleIframeLoad = () => {
     if (!onLoad) return null
@@ -25,11 +38,15 @@ function Iframe(props: Props) {
     return Function('IframeHandler', `"use strict";(${onLoad});`)(onLoad)
   }
 
+  const processSrc = () => srcAccount?.[runtime.account] ?? src
+
+  console.log('processSrc =>', processSrc())
+
   return (
     <div className={`${handles.container} w-100 flex justify-center`}>
       <iframe
         title={title}
-        src={src}
+        src={processSrc()}
         width={width}
         height={height}
         allow={allow}
@@ -49,6 +66,12 @@ Iframe.schema = {
     src: {
       title: 'editor.iframe.src.title',
       description: 'editor.iframe.src.description',
+      type: 'string',
+      default: null,
+    },
+    srcAccount: {
+      title: 'editor.iframe.srcAccount.title',
+      description: 'editor.iframe.srcAccount.description',
       type: 'string',
       default: null,
     },


### PR DESCRIPTION
#### What problem is this solving?
When you have different accounts using the same theme and need different URLs

#### How to test it?
In your theme, use the following syntax for the iframe.

```json
  "iframe#logout": {
    "props": {
      "src": "//www.mywebsiteprod.com/logout",
      "srcAccount": {
        "mywebsiteprod": "//www.mywebsite.com/logout",
        "mywebsiteqa": "//qa.mywebsite.com/logout"
      },
      "onLoad": "setTimeout(() => {window.location.href='/'}, 5000)",
      "className": "iframeLogout",
      "id": "iframeLogout"
    }
  },
```

It will always fallback to the src if the srcAccount is incorrect.