### PR TITLE
add support to custom pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- support to custom pages
+
+### Fixed
+
+- Fix src replacement
+
 ## [0.7.0] - 2023-07-11
 
 ### Added

--- a/react/DynamicIframe.tsx
+++ b/react/DynamicIframe.tsx
@@ -26,14 +26,15 @@ function DynamicIframe({
 }: Props) {
   const {
     route: { params, queryString },
-    query = {}
+    query = {},
   } = useRuntime()
 
-  const _dynamicParams:any = Object.keys(params).length ? params : queryString
+  const _dynamicParams: any = Object.keys(params).length ? params : queryString
 
   let allParamsExist = true
 
-  const queryStringSearch = Object.keys(params).length ? Object.keys(query).reduce((acc, key) => {
+  const queryStringSearch = Object.keys(params).length
+  ? Object.keys(query).reduce((acc, key) => {
     return `${acc || '?'}${key}=${query[key]}&`
   }, '') : ``;
 
@@ -48,7 +49,6 @@ function DynamicIframe({
     }
     return _dynamicParams[thisParam]
   })
-
 
   if (allParamsExist !== true || !src) {
     return null

--- a/react/DynamicIframe.tsx
+++ b/react/DynamicIframe.tsx
@@ -25,27 +25,30 @@ function DynamicIframe({
   onLoad,
 }: Props) {
   const {
-    route: { params },
-    query = {},
+    route: { params, queryString },
+    query = {}
   } = useRuntime()
 
-  const queryString = Object.keys(query).reduce((acc, key) => {
-    return `${acc || '?'}${key}=${query[key]}&`
-  }, '')
+  const _dynamicParams:any = Object.keys(params).length ? params : queryString
 
   let allParamsExist = true
 
+  const queryStringSearch = Object.keys(params).length ? Object.keys(query).reduce((acc, key) => {
+    return `${acc || '?'}${key}=${query[key]}&`
+  }, '') : ``;
+
   const src = dynamicSrc.replace(/({[A-z0-9]*})/g, (match: string) => {
     const thisParam = match.replace(/{|}/g, '')
-    if (!thisParam || !params[thisParam]) {
+    if (!thisParam || !_dynamicParams[thisParam]) {
       allParamsExist = false
       console.error(
-        `parameter ${thisParam} not found in runtime params: ${params}`
+        `parameter ${thisParam} not found in runtime params: ${_dynamicParams}`
       )
       return ''
     }
-    return params[thisParam]
+    return _dynamicParams[thisParam]
   })
+
 
   if (allParamsExist !== true || !src) {
     return null
@@ -54,7 +57,7 @@ function DynamicIframe({
   return (
     <Iframe
       title={title}
-      src={src + queryString}
+      src={src + queryStringSearch}
       width={width}
       height={height}
       allow={allow}

--- a/react/DynamicIframe.tsx
+++ b/react/DynamicIframe.tsx
@@ -35,9 +35,9 @@ function DynamicIframe({
 
   const queryStringSearch = Object.keys(params).length
     ? Object.keys(query).reduce((acc, key) => {
-          return `${acc || '?'}${key}=${query[key]}&`
+        return `${acc || '?'}${key}=${query[key]}&`
       }, '')
-    : ``;
+    : ``
 
   const src = dynamicSrc.replace(/({[A-z0-9]*})/g, (match: string) => {
     const thisParam = match.replace(/{|}/g, '')

--- a/react/DynamicIframe.tsx
+++ b/react/DynamicIframe.tsx
@@ -34,9 +34,10 @@ function DynamicIframe({
   let allParamsExist = true
 
   const queryStringSearch = Object.keys(params).length
-  ? Object.keys(query).reduce((acc, key) => {
-    return `${acc || '?'}${key}=${query[key]}&`
-  }, '') : ``;
+    ? Object.keys(query).reduce((acc, key) => {
+          return `${acc || '?'}${key}=${query[key]}&`
+      }, '')
+    : ``;
 
   const src = dynamicSrc.replace(/({[A-z0-9]*})/g, (match: string) => {
     const thisParam = match.replace(/{|}/g, '')


### PR DESCRIPTION
#### What problem is this solving?

This adds the supports for custom pages, since in the `routes.params` it comes empty

![image](https://github.com/vtex-apps/iframe/assets/25616893/a691c9e4-ef49-4128-bd36-bec0a1bd11dd)


#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace][https://vysk--beautycounter.myvtex.com/log-out?client_id=4488192](https://vysk--beautycounter.myvtex.com/log-out?client_id=4488192)

#### Screenshots or example usage:

<img width="1317" alt="image" src="https://github.com/vtex-apps/iframe/assets/25616893/b3f4a917-fc4a-4a91-be74-20b8f916c182">

![image](https://github.com/vtex-apps/iframe/assets/25616893/bc2bdd5a-cf8b-4f99-96ca-2f9a71387b2f)


#### Describe alternatives you've considered, if any.

Note that it follows more precisely what is described in the documentation instead of adding the querystring at the end. 
However, I kept it working as it's and just added the support on custom pages instead of doing major breaking change.


#### How does this PR make you feel? [:link:](http://giphy.com/)

![image](https://media.tenor.com/eRVIDzcxA0QAAAAM/friends-joey-tribbiani.gif)

